### PR TITLE
Preemptively set removal on cancelation in jvm metrics reporter to av…

### DIFF
--- a/code/jvm/src/main/scala/com/avast/datadog4s/extension/jvm/JvmMonitoring.scala
+++ b/code/jvm/src/main/scala/com/avast/datadog4s/extension/jvm/JvmMonitoring.scala
@@ -1,9 +1,9 @@
 package com.avast.datadog4s.extension.jvm
 
 import java.time.Duration
-import java.util.concurrent.{ Executors, ScheduledExecutorService, TimeUnit }
+import java.util.concurrent.{Executors, ScheduledExecutorService, ScheduledThreadPoolExecutor, ThreadFactory, TimeUnit}
 
-import cats.effect.{ Effect, IO, Resource, Sync }
+import cats.effect.{Effect, IO, Resource, Sync}
 import com.avast.datadog4s.api.MetricFactory
 
 object JvmMonitoring {
@@ -37,13 +37,18 @@ object JvmMonitoring {
     }
   }
 
-  private def makeScheduler(config: Config): ScheduledExecutorService =
-    Executors.newScheduledThreadPool(1, { r: Runnable =>
+  private def makeScheduler(config: Config): ScheduledExecutorService = {
+    val threadFactory: ThreadFactory = (r: Runnable) => {
       val thread = new Thread(r)
       thread.setName(s"${config.schedulerThreadName}-${thread.getId}")
       thread.setDaemon(true)
       thread
-    })
+    }
+
+    val executor = new ScheduledThreadPoolExecutor(1, threadFactory)
+    executor.setRemoveOnCancelPolicy(true)
+    executor
+  }
 
   private def runnable(reportMetrics: IO[Unit], errorHandler: ErrorHandler[IO]): Runnable =
     () => reportMetrics.handleErrorWith(errorHandler).unsafeRunSync()

--- a/code/jvm/src/main/scala/com/avast/datadog4s/extension/jvm/JvmMonitoring.scala
+++ b/code/jvm/src/main/scala/com/avast/datadog4s/extension/jvm/JvmMonitoring.scala
@@ -1,13 +1,7 @@
 package com.avast.datadog4s.extension.jvm
 
 import java.time.Duration
-import java.util.concurrent.{
-  Executors,
-  ScheduledExecutorService,
-  ScheduledThreadPoolExecutor,
-  ThreadFactory,
-  TimeUnit
-}
+import java.util.concurrent.{ ScheduledExecutorService, ScheduledThreadPoolExecutor, ThreadFactory, TimeUnit }
 
 import cats.effect.{ Effect, IO, Resource, Sync }
 import com.avast.datadog4s.api.MetricFactory

--- a/code/jvm/src/main/scala/com/avast/datadog4s/extension/jvm/JvmMonitoring.scala
+++ b/code/jvm/src/main/scala/com/avast/datadog4s/extension/jvm/JvmMonitoring.scala
@@ -1,9 +1,15 @@
 package com.avast.datadog4s.extension.jvm
 
 import java.time.Duration
-import java.util.concurrent.{Executors, ScheduledExecutorService, ScheduledThreadPoolExecutor, ThreadFactory, TimeUnit}
+import java.util.concurrent.{
+  Executors,
+  ScheduledExecutorService,
+  ScheduledThreadPoolExecutor,
+  ThreadFactory,
+  TimeUnit
+}
 
-import cats.effect.{Effect, IO, Resource, Sync}
+import cats.effect.{ Effect, IO, Resource, Sync }
 import com.avast.datadog4s.api.MetricFactory
 
 object JvmMonitoring {


### PR DESCRIPTION
Preemptively set removal on cancelation in jvm metrics reporter to avoid potential memory leak

To be clear, i don't think there was a memory leak in released versions, but i think it's a good practice to have set the removal policy non the less to avoid potential problems in the future