### PR TITLE
Make forever test more robust

### DIFF
--- a/code/common/src/test/scala/com/avast/cloud/datadog4s/helpers/RepeatedTest.scala
+++ b/code/common/src/test/scala/com/avast/cloud/datadog4s/helpers/RepeatedTest.scala
@@ -7,6 +7,7 @@ import cats.effect.{ ContextShift, IO, Timer }
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 import org.slf4j.LoggerFactory
+import cats.syntax.flatMap._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -26,9 +27,9 @@ class RepeatedTest extends AnyFlatSpec with Matchers {
         counter.modify { currentCount =>
           currentCount - 1 match {
             case newCounter if newCounter <= 0 => (newCounter, killSignal.complete(()))
-            case newCounter                    => (newCounter, IO.pure(()))
+            case newCounter                    => (newCounter, IO.unit)
           }
-        }.flatMap(identity)
+        }.flatten
 
       val process = Repeated.run[IO](Duration.ofMillis(5), Duration.ofMillis(50), noopErrHandler) {
         IO.delay(logger.info("increasing ref")) *> decreaseCounter *> IO.delay(logger.info("ref updated"))

--- a/code/common/src/test/scala/com/avast/cloud/datadog4s/helpers/RepeatedTest.scala
+++ b/code/common/src/test/scala/com/avast/cloud/datadog4s/helpers/RepeatedTest.scala
@@ -21,14 +21,12 @@ class RepeatedTest extends AnyFlatSpec with Matchers {
   "repeated test" should "be called repeatedly" in {
     val waitFor = 10
 
-    def buildProcess(counter: Ref[IO, Int], killSignal: Deferred[IO, Unit]) = {
+    def buildProcess(counter: Ref[IO, Int], killSignal: Deferred[IO, Unit]): IO[Int] = {
       def decreaseCounter: IO[Unit] =
-        counter.modify { c =>
-          val newC = c - 1
-          if (newC <= 0) {
-            (newC, killSignal.complete(()))
-          } else {
-            (newC, IO.pure(()))
+        counter.modify { currentCount =>
+          currentCount - 1 match {
+            case newCounter if newCounter <= 0 => (newCounter, killSignal.complete(()))
+            case newCounter                    => (newCounter, IO.pure(()))
           }
         }.flatMap(identity)
 


### PR DESCRIPTION
i think you gonna like it 

the previous test was sensitive to some odd conditions and was relying upon scheduling, it shouldn't anymore ...

btw it seems like `Timer.sleep(10ms) *> xxx` doesn't really guarantee that `xxx` will be executed even close to after 10 ms - often its much more