### PR TITLE
feat(jvm): made metric names compatible with datadog agent metric names

### DIFF
--- a/code/jvm/src/main/scala/com/avast/datadog4s/extension/jvm/JvmReporter.scala
+++ b/code/jvm/src/main/scala/com/avast/datadog4s/extension/jvm/JvmReporter.scala
@@ -54,7 +54,7 @@ class JvmReporter[F[_]: Sync](metricsFactory: MetricFactory[F]) {
   private val gc: Vector[F[Unit]] =
     gcBeans.map { bean =>
       val name   = bean.getName
-      val gcName = Tag.of("gc_name", bean.getName.replace(" ", "_"))
+      val gcName = Tag.of("gc_name", name.replace(" ", "_"))
       if (name.contains("young"))
         wrapUnsafe(gcMinorCollections, gcName)(bean.getCollectionCount) >>
           wrapUnsafe(gcMinorTime, gcName)(bean.getCollectionTime)
@@ -106,7 +106,7 @@ class JvmReporter[F[_]: Sync](metricsFactory: MetricFactory[F]) {
       getNonHeapCommittedIO >>
       getNonHeapUsedIO >>
       getNonHeapInitIO >>
-      getNonHeapInitIO >>
+      getNonHeapMaxIO >>
       getUptimeIO >>
       getThreadsTotalIO >>
       getThreadsDaemonIO >>

--- a/code/jvm/src/main/scala/com/avast/datadog4s/extension/jvm/JvmReporter.scala
+++ b/code/jvm/src/main/scala/com/avast/datadog4s/extension/jvm/JvmReporter.scala
@@ -19,20 +19,25 @@ class JvmReporter[F[_]: Sync](metricsFactory: MetricFactory[F]) {
   private val cpuLoad              = metricsFactory.gauge.double("jvm.cpu.load")
   private val cpuTime              = metricsFactory.gauge.long("jvm.cpu.time")
   private val openFds              = metricsFactory.gauge.long("jvm.filedescriptor.open")
-  private val heapUsed             = metricsFactory.gauge.long("jvm.heap.used")
-  private val heapCommitted        = metricsFactory.gauge.long("jvm.heap.committed")
-  private val heapMax              = metricsFactory.gauge.long("jvm.heap.max")
-  private val nonHeapUsed          = metricsFactory.gauge.long("jvm.nonheap.used")
-  private val nonHeapCommitted     = metricsFactory.gauge.long("jvm.nonheap.committed")
+  private val heapUsed             = metricsFactory.gauge.long("jvm.heap_memory")
+  private val heapCommitted        = metricsFactory.gauge.long("jvm.heap_memory_committed")
+  private val heapInit             = metricsFactory.gauge.long("jvm.heap_memory_init")
+  private val heapMax              = metricsFactory.gauge.long("jvm.heap_memory_max")
+  private val nonHeapUsed          = metricsFactory.gauge.long("jvm.non_heap_memory")
+  private val nonHeapCommitted     = metricsFactory.gauge.long("jvm.non_heap_memory_committed")
+  private val nonHeapInit          = metricsFactory.gauge.long("jvm.non_heap_memory_init")
+  private val nonHeapMax           = metricsFactory.gauge.long("jvm.non_heap_memory_max")
   private val uptime               = metricsFactory.gauge.long("jvm.uptime")
-  private val threadsTotal         = metricsFactory.gauge.long("jvm.threads.total")
-  private val threadsDaemon        = metricsFactory.gauge.long("jvm.threads.daemon")
-  private val threadsStarted       = metricsFactory.gauge.long("jvm.threads.started")
+  private val threadsTotal         = metricsFactory.gauge.long("jvm.thread_count")
+  private val threadsDaemon        = metricsFactory.gauge.long("jvm.thread_daemon")
+  private val threadsStarted       = metricsFactory.gauge.long("jvm.thread_started")
   private val classes              = metricsFactory.gauge.long("jvm.classes.loaded")
   private val bufferPoolsInstances = metricsFactory.gauge.long("jvm.bufferpool.instances")
   private val bufferPoolsBytes     = metricsFactory.gauge.long("jvm.bufferpool.bytes")
-  private val gcCollections        = metricsFactory.gauge.long("jvm.gc.collections")
-  private val gcTime               = metricsFactory.gauge.long("jvm.gc.time")
+  private val gcMinorCollections   = metricsFactory.gauge.long("jvm.gc.minor_collection_count")
+  private val gcMinorTime          = metricsFactory.gauge.long("jvm.gc.minor_collection_time")
+  private val gcMajorCollections   = metricsFactory.gauge.long("jvm.gc.major_collection_count")
+  private val gcMajorTime          = metricsFactory.gauge.long("jvm.gc.major_collection_time")
 
   private val osBean      = F.delay(ManagementFactory.getOperatingSystemMXBean.asInstanceOf[OperatingSystemMXBean])
   private val unixBean    = F.delay(ManagementFactory.getOperatingSystemMXBean.asInstanceOf[UnixOperatingSystemMXBean])
@@ -48,9 +53,14 @@ class JvmReporter[F[_]: Sync](metricsFactory: MetricFactory[F]) {
 
   private val gc: Vector[F[Unit]] =
     gcBeans.map { bean =>
+      val name   = bean.getName
       val gcName = Tag.of("gc_name", bean.getName.replace(" ", "_"))
-      wrapUnsafe(gcCollections, gcName)(bean.getCollectionCount) >>
-        wrapUnsafe(gcTime, gcName)(bean.getCollectionTime)
+      if (name.contains("young"))
+        wrapUnsafe(gcMinorCollections, gcName)(bean.getCollectionCount) >>
+          wrapUnsafe(gcMinorTime, gcName)(bean.getCollectionTime)
+      else
+        wrapUnsafe(gcMajorCollections, gcName)(bean.getCollectionCount) >>
+          wrapUnsafe(gcMajorTime, gcName)(bean.getCollectionTime)
     }
 
   private val buffers: Vector[F[Unit]] = bufferBeans.map { bean =>
@@ -66,9 +76,12 @@ class JvmReporter[F[_]: Sync](metricsFactory: MetricFactory[F]) {
   protected[jvm] val getOpenFDsCountIO     = protect(unixBean)(bean => wrapUnsafe(openFds)(bean.getOpenFileDescriptorCount))
   protected[jvm] val getHeapUsedIO         = wrapUnsafe(heapUsed)(memoryBean.getHeapMemoryUsage.getUsed)
   protected[jvm] val getHeapCommittedIO    = wrapUnsafe(heapCommitted)(memoryBean.getHeapMemoryUsage.getCommitted)
+  protected[jvm] val getHeapInitIO         = wrapUnsafe(heapInit)(memoryBean.getHeapMemoryUsage.getInit)
   protected[jvm] val getHeapMaxIO          = wrapUnsafe(heapMax)(memoryBean.getHeapMemoryUsage.getMax)
   protected[jvm] val getNonHeapCommittedIO = wrapUnsafe(nonHeapCommitted)(memoryBean.getNonHeapMemoryUsage.getCommitted)
   protected[jvm] val getNonHeapUsedIO      = wrapUnsafe(nonHeapUsed)(memoryBean.getNonHeapMemoryUsage.getUsed)
+  protected[jvm] val getNonHeapInitIO      = wrapUnsafe(nonHeapInit)(memoryBean.getNonHeapMemoryUsage.getInit)
+  protected[jvm] val getNonHeapMaxIO       = wrapUnsafe(nonHeapMax)(memoryBean.getNonHeapMemoryUsage.getMax)
   protected[jvm] val getUptimeIO           = wrapUnsafe(uptime)(runtimeBean.getUptime)
   protected[jvm] val getThreadsTotalIO     = wrapUnsafe(threadsTotal)(threadBean.getThreadCount.toLong)
   protected[jvm] val getThreadsDaemonIO    = wrapUnsafe(threadsDaemon)(threadBean.getDaemonThreadCount.toLong)
@@ -88,9 +101,12 @@ class JvmReporter[F[_]: Sync](metricsFactory: MetricFactory[F]) {
       getOpenFDsCountIO >>
       getHeapUsedIO >>
       getHeapCommittedIO >>
+      getHeapInitIO >>
       getHeapMaxIO >>
       getNonHeapCommittedIO >>
       getNonHeapUsedIO >>
+      getNonHeapInitIO >>
+      getNonHeapInitIO >>
       getUptimeIO >>
       getThreadsTotalIO >>
       getThreadsDaemonIO >>

--- a/code/jvm/src/test/scala/com/avast/datadog4s/extension/jvm/JvmMonitoringTest.scala
+++ b/code/jvm/src/test/scala/com/avast/datadog4s/extension/jvm/JvmMonitoringTest.scala
@@ -43,20 +43,24 @@ class JvmMonitoringTest extends AnyFlatSpec with Matchers {
     "jvm.cpu.load",
     "jvm.cpu.time",
     "jvm.filedescriptor.open",
-    "jvm.heap.used",
-    "jvm.heap.committed",
-    "jvm.heap.max",
-    "jvm.nonheap.used",
-    "jvm.nonheap.committed",
+    "jvm.heap_memory",
+    "jvm.heap_memory_committed",
+    "jvm.heap_memory_init",
+    "jvm.heap_memory_max",
+    "jvm.non_heap_memory",
+    "jvm.non_heap_memory_committed",
+    "jvm.non_heap_memory_init",
+    "jvm.non_heap_memory_max",
     "jvm.uptime",
-    "jvm.threads.total",
-    "jvm.threads.daemon",
-    "jvm.threads.started",
+    "jvm.thread_count",
+    "jvm.thread_daemon",
+    "jvm.thread_started",
     "jvm.classes.loaded",
     "jvm.bufferpool.instances",
     "jvm.bufferpool.bytes",
-    "jvm.gc.collections",
-    "jvm.gc.time"
+    // we do not explicitly verify minor collection count/time as we don't know what GC is going to be used
+    "jvm.gc.major_collection_time",
+    "jvm.gc.major_collection_count"
   )
 
 }


### PR DESCRIPTION
This PR makes JVM metric names compatible with [JMX collector](https://docs.datadoghq.com/integrations/java/?tab=host#data-collected).

This is a breaking change.