### PR TITLE
Allow distribution-based counters in http4s module

### DIFF
--- a/code/http4s/src/main/scala/com/avast/datadog4s/extension/http4s/MetricsOpsBuilder.scala
+++ b/code/http4s/src/main/scala/com/avast/datadog4s/extension/http4s/MetricsOpsBuilder.scala
@@ -30,14 +30,15 @@ import scala.annotation.nowarn
     copy(distributionBasedTimers = false)
 
   /** Force MetricOps to use [[com.avast.datadog4s.api.DistributionFactory DistributionFactory]] for counting http4s
-    * requests. For the implications please see
-    * [[com.avast.datadog4s.api.TimerFactory.distribution TimerFactory.distribution]] scaladoc.
+    * requests. This is useful in serverless models like AWS Lambda to aggregate all counter values. For more info see
+    * [[https://docs.datadoghq.com/serverless/custom_metrics/#understanding-distribution-metrics Datadog documentation]].
     */
   def useDistributionBasedCounters(): MetricsOpsBuilder[F] =
     copy(distributionBasedCounters = true)
 
-  /** Force MetricOps to use [[com.avast.datadog4s.api.metric.Count Count]] for counting http4s requests. For the
-    * implications please see [[com.avast.datadog4s.api.TimerFactory.histogram TimerFactory.histogram]] scaladoc.
+  /** Force MetricOps to use [[com.avast.datadog4s.api.metric.Count Count]] for counting http4s requests. This is
+    * sufficient for requests on servers where the host is automatically added as a tag. For more info see
+    * [[https://docs.datadoghq.com/serverless/custom_metrics/#understanding-distribution-metrics Datadog documentation]].
     */
   def useHistogramBasedCounters(): MetricsOpsBuilder[F] =
     copy(distributionBasedCounters = false)

--- a/code/http4s/src/main/scala/com/avast/datadog4s/extension/http4s/impl/DefaultMetricsOps.scala
+++ b/code/http4s/src/main/scala/com/avast/datadog4s/extension/http4s/impl/DefaultMetricsOps.scala
@@ -6,7 +6,6 @@ import cats.syntax.flatMap.*
 import com.avast.datadog4s.api.MetricFactory
 import com.avast.datadog4s.api.metric.Timer
 import com.avast.datadog4s.api.tag.Tagger
-import com.avast.datadog4s.api.Tag
 import com.avast.datadog4s.extension.http4s.DatadogMetricsOps.ClassifierTags
 import com.avast.datadog4s.extension.http4s.*
 import org.http4s.metrics.{MetricsOps, TerminationType}

--- a/code/http4s/src/main/scala/com/avast/datadog4s/extension/http4s/impl/GenericCounter.scala
+++ b/code/http4s/src/main/scala/com/avast/datadog4s/extension/http4s/impl/GenericCounter.scala
@@ -1,0 +1,21 @@
+package com.avast.datadog4s.extension.http4s.impl
+
+import com.avast.datadog4s.api.MetricFactory
+import com.avast.datadog4s.api.Tag
+
+private[http4s] sealed trait GenericCounter[F[_]] {
+  def inc(tags: Tag*): F[Unit]
+}
+
+private[http4s] object GenericCounter {
+  final class CountWrapper[F[_]](metricFactory: MetricFactory[F], aspect: String) extends GenericCounter[F] {
+    private val counter = metricFactory.count(aspect)
+
+    override def inc(tags: Tag*): F[Unit] = counter.inc(tags*)
+  }
+  final class DistributionCounter[F[_]](metricFactory: MetricFactory[F], aspect: String) extends GenericCounter[F] {
+    private val counter = metricFactory.distribution.long(aspect)
+
+    override def inc(tags: Tag*): F[Unit] = counter.record(1L, tags*)
+  }
+}


### PR DESCRIPTION
We noticed that the counters in this http4s module were getting overwritten by different invocations of our lambdas. The timers are configurable to be distribution-based, we should allow counters to be distribution-based as well. Happy to make any changes you recommend! Thanks. 