### PR TITLE
fix(http4s): use distribution instead of gauge for active_requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## Unreleased
+-   **http4s**: Added `useDistributionBasedActiveRequests()` option to `MetricsOpsBuilder`. The `active_requests` gauge
+    uses last-value-wins StatsD flushing, which drops intra-flush peaks and can hide concurrency limit breaches.
+    Enabling this option switches `active_requests` to a distribution metric so max/avg/p99 are preserved across the
+    flush interval.
+    **Note**: switching metric type breaks existing Datadog dashboards and monitors querying `active_requests` as a
+    gauge — update those queries to use the `max` aggregation after enabling this option.
+
 ## 0.7.3 and going forward
 *Going forward, changes will be tracked in release notes*
 

--- a/code/http4s/src/main/scala/io/github/datadog4s/extension/http4s/MetricsOpsBuilder.scala
+++ b/code/http4s/src/main/scala/io/github/datadog4s/extension/http4s/MetricsOpsBuilder.scala
@@ -50,12 +50,13 @@ import scala.annotation.nowarn
     * 10s) are visible in Datadog.
     *
     * '''Breaking change for existing dashboards''': switching metric type will break existing dashboards and monitors
-    * querying active_requests as a gauge — update those queries to use the `max` aggregation after enabling this option.
+    * querying active_requests as a gauge — update those queries to use the `max` aggregation after enabling this
+    * option.
     *
     * '''Idle-period gaps''': unlike a gauge (which the StatsD agent re-emits every flush even when unchanged), a
-    * distribution only emits data when a request arrives or completes. During flush intervals with zero active requests,
-    * no data point is sent and Datadog will show a gap. Monitors configured to alert on "no data" may fire spuriously
-    * on idle or low-traffic services.
+    * distribution only emits data when a request arrives or completes. During flush intervals with zero active
+    * requests, no data point is sent and Datadog will show a gap. Monitors configured to alert on "no data" may fire
+    * spuriously on idle or low-traffic services.
     */
   def useDistributionBasedActiveRequests(): MetricsOpsBuilder[F] =
     copy(distributionBasedActiveRequests = true)

--- a/code/http4s/src/main/scala/io/github/datadog4s/extension/http4s/MetricsOpsBuilder.scala
+++ b/code/http4s/src/main/scala/io/github/datadog4s/extension/http4s/MetricsOpsBuilder.scala
@@ -13,6 +13,7 @@ import scala.annotation.nowarn
     metricFactory: MetricFactory[F],
     distributionBasedTimers: Boolean,
     distributionBasedCounters: Boolean,
+    distributionBasedActiveRequests: Boolean,
     classifierTags: ClassifierTags
 ) {
 
@@ -44,6 +45,20 @@ import scala.annotation.nowarn
   def useHistogramBasedCounters(): MetricsOpsBuilder[F] =
     copy(distributionBasedCounters = false)
 
+  /** Force MetricOps to use [[io.github.datadog4s.api.DistributionFactory DistributionFactory]] for tracking
+    * active_requests. This preserves intra-flush peaks so spikes that resolve within the StatsD flush interval
+    * (default 10s) are visible in Datadog. Note that switching metric type will break existing dashboards and monitors
+    * querying active_requests as a gauge — update those queries to use the `max` aggregation after enabling this option.
+    */
+  def useDistributionBasedActiveRequests(): MetricsOpsBuilder[F] =
+    copy(distributionBasedActiveRequests = true)
+
+  /** Force MetricOps to use a gauge for tracking active_requests. Only the last value in each StatsD flush interval is
+    * sent to Datadog, so intra-flush peaks may be lost. This is the default.
+    */
+  def useGaugeBasedActiveRequests(): MetricsOpsBuilder[F] =
+    copy(distributionBasedActiveRequests = false)
+
   /** Function for computing tags based on provided classifier. By default uses
     * [[MetricsOpsBuilder.defaultClassifierTags]]
     */
@@ -54,7 +69,7 @@ import scala.annotation.nowarn
     Ref
       .of[F, ActiveConnections](Map.empty)
       .map(
-        new DefaultMetricsOps[F](metricFactory, classifierTags, _, distributionBasedTimers, distributionBasedCounters)
+        new DefaultMetricsOps[F](metricFactory, classifierTags, _, distributionBasedTimers, distributionBasedCounters, distributionBasedActiveRequests)
       )
 }
 
@@ -66,6 +81,7 @@ object MetricsOpsBuilder {
       metricFactory,
       distributionBasedTimers = false,
       distributionBasedCounters = false,
+      distributionBasedActiveRequests = false,
       classifierTags = defaultClassifierTags
     )
 }

--- a/code/http4s/src/main/scala/io/github/datadog4s/extension/http4s/MetricsOpsBuilder.scala
+++ b/code/http4s/src/main/scala/io/github/datadog4s/extension/http4s/MetricsOpsBuilder.scala
@@ -13,7 +13,7 @@ import scala.annotation.nowarn
     metricFactory: MetricFactory[F],
     distributionBasedTimers: Boolean,
     distributionBasedCounters: Boolean,
-    distributionBasedActiveRequests: Boolean,
+    distributionBasedActiveRequests: Boolean = false,
     classifierTags: ClassifierTags
 ) {
 
@@ -46,9 +46,16 @@ import scala.annotation.nowarn
     copy(distributionBasedCounters = false)
 
   /** Force MetricOps to use [[io.github.datadog4s.api.DistributionFactory DistributionFactory]] for tracking
-    * active_requests. This preserves intra-flush peaks so spikes that resolve within the StatsD flush interval
-    * (default 10s) are visible in Datadog. Note that switching metric type will break existing dashboards and monitors
+    * active_requests. This preserves intra-flush peaks so spikes that resolve within the StatsD flush interval (default
+    * 10s) are visible in Datadog.
+    *
+    * '''Breaking change for existing dashboards''': switching metric type will break existing dashboards and monitors
     * querying active_requests as a gauge — update those queries to use the `max` aggregation after enabling this option.
+    *
+    * '''Idle-period gaps''': unlike a gauge (which the StatsD agent re-emits every flush even when unchanged), a
+    * distribution only emits data when a request arrives or completes. During flush intervals with zero active requests,
+    * no data point is sent and Datadog will show a gap. Monitors configured to alert on "no data" may fire spuriously
+    * on idle or low-traffic services.
     */
   def useDistributionBasedActiveRequests(): MetricsOpsBuilder[F] =
     copy(distributionBasedActiveRequests = true)
@@ -69,7 +76,14 @@ import scala.annotation.nowarn
     Ref
       .of[F, ActiveConnections](Map.empty)
       .map(
-        new DefaultMetricsOps[F](metricFactory, classifierTags, _, distributionBasedTimers, distributionBasedCounters, distributionBasedActiveRequests)
+        new DefaultMetricsOps[F](
+          metricFactory,
+          classifierTags,
+          _,
+          distributionBasedTimers,
+          distributionBasedCounters,
+          distributionBasedActiveRequests
+        )
       )
 }
 

--- a/code/http4s/src/main/scala/io/github/datadog4s/extension/http4s/impl/DefaultMetricsOps.scala
+++ b/code/http4s/src/main/scala/io/github/datadog4s/extension/http4s/impl/DefaultMetricsOps.scala
@@ -25,7 +25,7 @@ private[http4s] class DefaultMetricsOps[F[_]](
   private val terminationTypeTagger = Tagger.make[TerminationType]("termination_type")
   private val statusCodeTagger      = Tagger.make[Status]("status_code")
   private val statusBucketTagger    = Tagger.make[String]("status_bucket")
-  private val activeRequests        = metricFactory.gauge.long("active_requests")
+  private val activeRequests        = metricFactory.distribution.long("active_requests")
 
   override def increaseActiveRequests(classifier: Option[String]): F[Unit] =
     modifyActiveRequests(classifier, 0, 1)
@@ -39,7 +39,7 @@ private[http4s] class DefaultMetricsOps[F[_]](
       val current               = activeConnections.getOrElse(classifier, default)
       val next                  = current + delta
       val nextActiveConnections = activeConnections.updated(classifier, next)
-      val action                = activeRequests.set(
+      val action                = activeRequests.record(
         next.toLong,
         classifier.toList.flatMap(classifierTags)*
       )

--- a/code/http4s/src/main/scala/io/github/datadog4s/extension/http4s/impl/DefaultMetricsOps.scala
+++ b/code/http4s/src/main/scala/io/github/datadog4s/extension/http4s/impl/DefaultMetricsOps.scala
@@ -22,10 +22,10 @@ private[http4s] class DefaultMetricsOps[F[_]](
     F: Sync[F]
 ) extends MetricsOps[F] {
 
-  private val methodTagger          = Tagger.make[Method]("method")
-  private val terminationTypeTagger = Tagger.make[TerminationType]("termination_type")
-  private val statusCodeTagger      = Tagger.make[Status]("status_code")
-  private val statusBucketTagger    = Tagger.make[String]("status_bucket")
+  private val methodTagger                                      = Tagger.make[Method]("method")
+  private val terminationTypeTagger                             = Tagger.make[TerminationType]("termination_type")
+  private val statusCodeTagger                                  = Tagger.make[Status]("status_code")
+  private val statusBucketTagger                                = Tagger.make[String]("status_bucket")
   private val recordActiveRequests: (Long, Seq[Tag]) => F[Unit] =
     if (distributionBasedActiveRequests) {
       val dist = metricFactory.distribution.long("active_requests")

--- a/code/http4s/src/main/scala/io/github/datadog4s/extension/http4s/impl/DefaultMetricsOps.scala
+++ b/code/http4s/src/main/scala/io/github/datadog4s/extension/http4s/impl/DefaultMetricsOps.scala
@@ -3,7 +3,7 @@ package io.github.datadog4s.extension.http4s.impl
 import java.time.Duration
 import cats.effect.{Ref, Sync}
 import cats.syntax.flatMap.*
-import io.github.datadog4s.api.MetricFactory
+import io.github.datadog4s.api.{MetricFactory, Tag}
 import io.github.datadog4s.extension.http4s.DatadogMetricsOps.ClassifierTags
 import io.github.datadog4s.extension.http4s.*
 import io.github.datadog4s.api.metric.Timer
@@ -16,7 +16,8 @@ private[http4s] class DefaultMetricsOps[F[_]](
     classifierTags: ClassifierTags,
     activeConnectionsRef: Ref[F, ActiveConnections],
     distributionBasedTimers: Boolean,
-    distributionBasedCounters: Boolean
+    distributionBasedCounters: Boolean,
+    distributionBasedActiveRequests: Boolean
 )(implicit
     F: Sync[F]
 ) extends MetricsOps[F] {
@@ -25,7 +26,14 @@ private[http4s] class DefaultMetricsOps[F[_]](
   private val terminationTypeTagger = Tagger.make[TerminationType]("termination_type")
   private val statusCodeTagger      = Tagger.make[Status]("status_code")
   private val statusBucketTagger    = Tagger.make[String]("status_bucket")
-  private val activeRequests        = metricFactory.distribution.long("active_requests")
+  private val recordActiveRequests: (Long, Seq[Tag]) => F[Unit] =
+    if (distributionBasedActiveRequests) {
+      val dist = metricFactory.distribution.long("active_requests")
+      (v, tags) => dist.record(v, tags*)
+    } else {
+      val gauge = metricFactory.gauge.long("active_requests")
+      (v, tags) => gauge.set(v, tags*)
+    }
 
   override def increaseActiveRequests(classifier: Option[String]): F[Unit] =
     modifyActiveRequests(classifier, 0, 1)
@@ -39,10 +47,7 @@ private[http4s] class DefaultMetricsOps[F[_]](
       val current               = activeConnections.getOrElse(classifier, default)
       val next                  = current + delta
       val nextActiveConnections = activeConnections.updated(classifier, next)
-      val action                = activeRequests.record(
-        next.toLong,
-        classifier.toList.flatMap(classifierTags)*
-      )
+      val action                = recordActiveRequests(next.toLong, classifier.toList.flatMap(classifierTags))
       (nextActiveConnections, action)
     }.flatten
 


### PR DESCRIPTION
## Summary

The `active_requests` gauge uses last-value-wins StatsD flushing — only the most recent value in each flush interval (default 10s) is sent to Datadog. If active requests spikes and recovers within a flush window, the spike is invisible in Datadog, making it impossible to detect when a service hits its concurrency limit.

This PR adds a `useDistributionBasedActiveRequests()` option to `MetricsOpsBuilder` that switches `active_requests` to a distribution metric, which records every value and computes max/avg/p99 server-side so peaks within a flush interval are preserved.

The default remains gauge for backward compatibility.

## Usage

```scala
MetricsOpsBuilder
  .withDefaults(metricFactory)
  .useDistributionBasedActiveRequests()
  .build()
```

After enabling, use the `max` aggregation in Datadog queries to see peak active requests over each interval.

## Migration note / breaking change

Calling `useDistributionBasedActiveRequests()` changes the metric type from gauge to distribution. **Existing Datadog dashboards and monitors querying `active_requests` as a gauge will break** when this option is enabled — update those queries to use the `max` aggregation.
