### PR TITLE
Add Scalafix rule for com.avast.datadog4s -> io.github.datadog4s package rename

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,6 +129,52 @@ lazy val playground = project
   .dependsOn(statsd)
   .dependsOn(jvm)
 
+// Scalafix rule that rewrites the pre-migration `com.avast[.cloud].datadog4s` packages to
+// `io.github.datadog4s`. Consumed by Scala Steward via a `github:` reference; not published.
+lazy val scalafixRules = project
+  .in(file("scalafix/rules"))
+  .settings(
+    name                                   := "datadog4s-scalafix",
+    scalaVersion                           := scala213,
+    libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % _root_.scalafix.sbt.BuildInfo.scalafixVersion,
+    publish / skip                         := true
+  )
+  .disablePlugins(MimaPlugin)
+
+lazy val scalafixInput = project
+  .in(file("scalafix/input"))
+  .settings(
+    scalaVersion      := scala213,
+    semanticdbEnabled := true,
+    publish / skip    := true
+  )
+  .disablePlugins(MimaPlugin)
+
+lazy val scalafixOutput = project
+  .in(file("scalafix/output"))
+  .settings(
+    scalaVersion   := scala213,
+    publish / skip := true
+  )
+  .disablePlugins(MimaPlugin)
+
+lazy val scalafixTests = project
+  .in(file("scalafix/tests"))
+  .settings(
+    scalaVersion   := scala213,
+    publish / skip := true,
+    libraryDependencies += "ch.epfl.scala" %% "scalafix-testkit" % _root_.scalafix.sbt.BuildInfo.scalafixVersion % Test cross CrossVersion.full,
+    libraryDependencies += Dependencies.Testing.scalatest % Test,
+    scalafixTestkitOutputSourceDirectories               := (scalafixOutput / Compile / sourceDirectories).value,
+    scalafixTestkitInputSourceDirectories                := (scalafixInput / Compile / sourceDirectories).value,
+    scalafixTestkitInputClasspath                        := (scalafixInput / Compile / fullClasspath).value,
+    scalafixTestkitInputScalacOptions                    := (scalafixInput / Compile / scalacOptions).value,
+    scalafixTestkitInputScalaVersion                     := (scalafixInput / Compile / scalaVersion).value
+  )
+  .dependsOn(scalafixInput, scalafixRules)
+  .enablePlugins(ScalafixTestkitPlugin)
+  .disablePlugins(MimaPlugin)
+
 lazy val site = (project in file("site"))
   .settings(scalaSettings)
   .settings(commonSettings)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,6 +16,7 @@ object Dependencies {
   object Testing {
     val mockitoScalatest = "org.mockito"   %% "mockito-scala-scalatest" % "1.15.1"
     val munit            = "org.scalameta" %% "munit"                   % "1.3.3"
+    val scalatest        = "org.scalatest" %% "scalatest"               % "3.2.19"
   }
 
   object Logging {

--- a/scalafix/input/src/main/scala/fix/Datadog4sImports.scala
+++ b/scalafix/input/src/main/scala/fix/Datadog4sImports.scala
@@ -1,0 +1,27 @@
+/*
+rule = Datadog4s
+ */
+package fix
+
+import com.avast.datadog4s.api.MetricFactory
+import com.avast.datadog4s.api.Tagger
+import com.avast.cloud.datadog4s.helpers.Repeated
+
+object Datadog4sImports {
+  val factory: MetricFactory = null
+  val tagger: Tagger         = null
+  val repeated: Repeated     = null
+
+  // fully-qualified reference
+  def make: com.avast.datadog4s.api.MetricFactory = null
+}
+
+// Self-contained stubs so the input project compiles without the datadog4s classpath.
+// The rule is purely syntactic, so it rewrites these package/reference names regardless.
+package com.avast.datadog4s.api {
+  class MetricFactory
+  class Tagger
+}
+package com.avast.cloud.datadog4s.helpers {
+  class Repeated
+}

--- a/scalafix/output/src/main/scala/fix/Datadog4sImports.scala
+++ b/scalafix/output/src/main/scala/fix/Datadog4sImports.scala
@@ -1,0 +1,24 @@
+package fix
+
+import io.github.datadog4s.api.MetricFactory
+import io.github.datadog4s.api.Tagger
+import io.github.datadog4s.helpers.Repeated
+
+object Datadog4sImports {
+  val factory: MetricFactory = null
+  val tagger: Tagger         = null
+  val repeated: Repeated     = null
+
+  // fully-qualified reference
+  def make: io.github.datadog4s.api.MetricFactory = null
+}
+
+// Self-contained stubs so the input project compiles without the datadog4s classpath.
+// The rule is purely syntactic, so it rewrites these package/reference names regardless.
+package com.avast.datadog4s.api {
+  class MetricFactory
+  class Tagger
+}
+package com.avast.cloud.datadog4s.helpers {
+  class Repeated
+}

--- a/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,0 +1,1 @@
+fix.Datadog4s

--- a/scalafix/rules/src/main/scala/fix/Datadog4s.scala
+++ b/scalafix/rules/src/main/scala/fix/Datadog4s.scala
@@ -1,0 +1,54 @@
+package fix
+
+import scalafix.v1._
+import scala.meta._
+
+/** Rewrites references to the pre-migration `com.avast[.cloud].datadog4s` packages to the current `io.github.datadog4s`
+  * packages.
+  *
+  * datadog4s moved its group id from `com.avast.cloud` to `io.github.datadog4s` (see
+  * https://github.com/DataDog4s/datadog4s/pull/1029) and renamed its packages to match:
+  *
+  *   - `com.avast.cloud.datadog4s.*` -> `io.github.datadog4s.*`
+  *   - `com.avast.datadog4s.*` -> `io.github.datadog4s.*`
+  *
+  * This is a purely syntactic prefix rename, so no SemanticDB is required.
+  */
+class Datadog4s extends SyntacticRule("Datadog4s") {
+
+  // Longest prefix first: `com.avast.cloud.datadog4s` must be tested before `com.avast.datadog4s`.
+  private val renames: List[(String, String)] = List(
+    "com.avast.cloud.datadog4s" -> "io.github.datadog4s",
+    "com.avast.datadog4s"       -> "io.github.datadog4s"
+  )
+
+  override def fix(implicit doc: SyntacticDocument): Patch =
+    doc.tree.collect {
+      // `import com.avast.datadog4s.api.Tagger` / `import com.avast.cloud.datadog4s.helpers._`
+      case importer: Importer =>
+        patchRef(importer.ref)
+
+      // Fully-qualified usages such as `com.avast.datadog4s.api.MetricFactory.make(...)`.
+      // Only rewrite the outermost qualified reference; nested `Term.Select`s are subtrees of it.
+      // Skip refs that are:
+      //   - inside a larger `Term.Select` (handled by the outer one),
+      //   - an `Importer` ref (handled by the `Importer` case above), or
+      //   - a `package com.avast.datadog4s...` declaration (the rule targets consumer code).
+      case select: Term.Select if !select.parent.exists(p => p.is[Term.Select] || p.is[Importer] || p.is[Pkg]) =>
+        patchRef(select)
+    }.asPatch
+
+  /** If `ref` is a qualified reference beginning with one of the renamed prefixes, replaces the whole reference with
+    * the rewritten one. Uses the reference's own syntax so the trailing path (`.api.Tagger`, `.helpers`, ...) is
+    * preserved exactly.
+    */
+  private def patchRef(ref: Tree): Patch = {
+    val syntax = ref.syntax
+    renames
+      .collectFirst {
+        case (before, after) if syntax == before || syntax.startsWith(before + ".") =>
+          Patch.replaceTree(ref, after + syntax.substring(before.length))
+      }
+      .getOrElse(Patch.empty)
+  }
+}

--- a/scalafix/tests/src/test/scala/fix/RuleSuite.scala
+++ b/scalafix/tests/src/test/scala/fix/RuleSuite.scala
@@ -1,0 +1,8 @@
+package fix
+
+import scalafix.testkit.AbstractSemanticRuleSuite
+import org.scalatest.funsuite.AnyFunSuiteLike
+
+class RuleSuite extends AbstractSemanticRuleSuite with AnyFunSuiteLike {
+  runAllTests()
+}


### PR DESCRIPTION
## What

Adds a syntactic Scalafix rule, `Datadog4s`, that rewrites the pre-migration
package prefixes to the current ones:

- `com.avast.cloud.datadog4s.*` → `io.github.datadog4s.*`
- `com.avast.datadog4s.*` → `io.github.datadog4s.*`

It rewrites both `import`s and fully-qualified references, and deliberately
leaves `package` declarations alone (it targets consumer code).

## Why

The group-id + package rename in #1029 (`com.avast.cloud` → `io.github.datadog4s`)
means downstream code must update its imports. This rule lets users do that
automatically, and lets [Scala Steward](https://github.com/scala-steward-org/scala-steward)
apply it as part of the version bump.

Note: this depends on a release that actually ships the renamed
`io.github.datadog4s.*` packages — the latest published artifact
(`io.github.datadog4s:datadog4s-api:0.33.9`) still contains `com.avast.datadog4s.*`.
Release request: #1360.

The artifact (build-coordinate) side of this move is already handled in Scala
Steward: scala-steward-org/scala-steward#3920. This rule is the code-rewrite
complement.

## Layout

Standard scalafix modules, none published (`publish / skip := true`):

- `scalafix/rules` — the `Datadog4s` rule + service registration
- `scalafix/input` / `scalafix/output` — test fixtures
- `scalafix/tests` — testkit suite

Verified with `sbt scalafixTests/test` (green).

## Follow-up: Scala Steward registration

Once a release carrying the renamed packages is tagged, this entry can be added
to Scala Steward's [`scalafix-migrations.conf`](https://github.com/scala-steward-org/scala-steward/blob/main/modules/core/src/main/resources/scalafix-migrations.conf)
(**awaiting release** — fill in the version and tag):

```hocon
{
  groupId: "io.github.datadog4s",
  artifactIds: ["datadog4s.*"],
  newVersion: "<FIRST_RELEASE_WITH_RENAMED_PACKAGES>",
  rewriteRules: ["github:DataDog4s/datadog4s/Datadog4s?sha=<TAG_OR_SHA>"],
  doc: "https://github.com/DataDog4s/datadog4s/pull/1361"
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
